### PR TITLE
Update rtl_433_mqtt_hass.py

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant Add-ons: Slacker Labs",
-  "url": "https://github.com/thejeffreystone/hassio-addons",
-  "maintainer": "Jeffrey Stone"
+  "url": "https://github.com/TomWS1/hassio_addons/tree/TomWS1-patch-1",
+  "maintainer": "Thomas Studwell"
 }

--- a/sdr2mqtt/rtl_433_mqtt_hass.py
+++ b/sdr2mqtt/rtl_433_mqtt_hass.py
@@ -139,7 +139,7 @@ mappings = {
             "device_class": "battery",
             "name": "Battery",
             "unit_of_measurement": "%",
-            "value_template": "{{ float(value|int) * 99 + 1 }}"
+            "value_template": "{{ (float(value) * 99 + 1) | int }}"
         }
     },
 


### PR DESCRIPTION
Modified battery_ok entity to get full range of device percentage level, previous version truncated to 0 or 100 only.