### PR TITLE
Add fields required for statistics

### DIFF
--- a/acurite2mqtt/rtl_433_mqtt_hass.py
+++ b/acurite2mqtt/rtl_433_mqtt_hass.py
@@ -559,6 +559,8 @@ def publish_config(mqttc, topic, model, instance, channel, mapping):
     config["unique_id"] = "".join(["rtl433", device_type, instance, object_suffix])
     config["availability_topic"] = "/".join([MQTT_TOPIC, "status"])
     config["expire_after"] = EXPIRE_AFTER
+    config["last_reset"] = "homeassistant.util.dt.utc_from_timestamp(0)"
+    config["state_class"] = "measurement"
 
     # add Home Assistant device info
 
@@ -593,7 +595,7 @@ def bridge_event_to_hass(mqttc, topic, data):
     if not instance:
         # no unique device identifier
         return
-    
+
     if (WHITELIST_ENABLE == 'true') and (instance not in whitelist_list):
         # not an authorized device
         if DEBUG == 'true':


### PR DESCRIPTION
Home assistant statistics cards do not work without a couple of extra configurations set. See the links below for more information.

https://community.home-assistant.io/t/long-term-statistics-from-mqtt/326990
https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

Proof it works:
![atlas](https://user-images.githubusercontent.com/6100936/205415954-d3d6e4e2-47f6-4b3f-ad24-76c833a29da3.png)
