### PR TITLE
Add PM2.5 / PM 10 & Storm Distance KM to mappings

### DIFF
--- a/acurite2mqtt/rtl_433_mqtt_hass.py
+++ b/acurite2mqtt/rtl_433_mqtt_hass.py
@@ -535,6 +535,18 @@ mappings = {
         }
     },
 
+    "storm_dist_km": {
+        "device_type": "sensor",
+        "object_suffix": "stdist",
+        "config": {
+            "device_class":"distance",
+            "state_class":"measurement",
+            "name": "Lightning Distance Km",
+            "unit_of_measurement": "km",
+            "value_template": "{{ value|int }}"
+        }
+    },
+
     "strike_distance": {
         "device_type": "sensor",
         "object_suffix": "stdist",
@@ -563,6 +575,24 @@ mappings = {
         "config": {
             "name": "Lightning Strike Count",
             "state_class":"total_increasing",
+            "value_template": "{{ value|int }}"
+        }
+    },
+    "pm2_5_ug_m3": {
+        "device_type": "sensor",
+        "object_suffix": "pm_25",
+        "config": {
+            "name": "PM2.5 Mass Concentration",
+            "state_class":"measurement",
+            "value_template": "{{ value|int }}"
+        }
+    },
+    "pm10_0_ug_m3": {
+        "device_type": "sensor",
+        "object_suffix": "pm_10",
+        "config": {
+            "name": "PM10 Mass Concentraton",
+            "state_class":"measurement",
             "value_template": "{{ value|int }}"
         }
     },

--- a/acurite2mqtt/rtl_433_mqtt_hass.py
+++ b/acurite2mqtt/rtl_433_mqtt_hass.py
@@ -341,6 +341,8 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WD",
         "config": {
+            "device_class": "wind_direction",
+            "state_class": "measurement_angle",
             "name": "Wind Direction",
             "unit_of_measurement": "°",
             "value_template": "{{ value|float }}"
@@ -534,7 +536,6 @@ mappings = {
             "value_template": "{{ value|int }}"
         }
     },
-
     "storm_dist_km": {
         "device_type": "sensor",
         "object_suffix": "stdist",
@@ -582,6 +583,8 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "pm_25",
         "config": {
+            "device_class": "pm25",
+            "unit_of_measurement": "µg/m³",
             "name": "PM2.5 Mass Concentration",
             "state_class":"measurement",
             "value_template": "{{ value|int }}"
@@ -591,6 +594,8 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "pm_10",
         "config": {
+            "device_class": "pm10",
+            "unit_of_measurement": "µg/m³",
             "name": "PM10 Mass Concentraton",
             "state_class":"measurement",
             "value_template": "{{ value|int }}"


### PR DESCRIPTION
Hi there.

I've added mappings for additionally supported Bresser weather station 7-in-1 and lightning sensors.  I'm running the latest rtl-433 locally, but hopefully the version that you're using also supports these values.