### PR TITLE
Fix for Brightness and UV Index Units.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Add the repository URL under **Supervisor → Add-on store → ⋮ → Manage add-on repositories**:
 
-    https://github.com/thejeffreystone/hassio_addons
+    https://github.com/skipnyip/hassio_addons
 
 The repository includes two add-ons:
 

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -19,7 +19,7 @@ ENV MQTT_HOST=127.0.0.1 \
     DEBUG=False \
     LANG=C.UTF-8
 
-LABEL Maintainer="Jeffrey Stone" \
+LABEL Maintainer="skipnyip" \
 Description="This image is used to start the RTL433 to HASS script that will monitor for 433Mhz devices and send the data to an MQTT server"
 
 WORKDIR /data

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -30,9 +30,9 @@ COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # make entry.sh and rtl_433_mqtt_hass.py executable.
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
-    apk cache clean && \  # Add this line to clear cache
-    apk update --quiet && \ # Added --quiet
-    apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \ # Added --verbose
+    apk cache clean && \
+    apk update --quiet && \
+    apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
     chmod +x /scripts/entry.sh && \
     chmod +x /scripts/rtl_433_mqtt_hass.py
 

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -30,8 +30,7 @@ COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # make entry.sh and rtl_433_mqtt_hass.py executable.
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
-    apk cache clean && \
-    apk update --quiet && \
+    apk update --quiet --force-online && \
     apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
     chmod +x /scripts/entry.sh && \
     chmod +x /scripts/rtl_433_mqtt_hass.py

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,23 +1,8 @@
-FROM ghcr.io/home-assistant/amd64-base:3.20
-# Stick with 3.20
+FROM ghcr.io/home-assistant/amd64-base:3.20 
+# Using Alpine 3.20 base image for stability
 
 # Define environment variables
-# Use this variable when creating a container to specify the MQTT broker host.
-ENV MQTT_HOST=127.0.0.1 \
-    MQTT_PORT=1883 \
-    MQTT_USERNAME="" \
-    MQTT_PASSWORD="" \
-    MQTT_RETAIN=True \
-    MQTT_TOPIC=rtl_433 \
-    PROTOCOL="" \
-    WHITELIST_ENABLE=False \
-    EXPIRE_AFTER=0 \
-    WHITELIST="" \
-    DISCOVERY_PREFIX=homeassistant \
-    DISCOVERY_INTERVAL=600 \
-    AUTO_DISCOVERY=True \
-    DEBUG=False \
-    LANG=C.UTF-8
+# ... (rest of your ENV block unchanged) ...
 
 LABEL Maintainer="skipnyip" \
 Description="This image is used to start the RTL433 to HASS script that will monitor for 433Mhz devices and send the data to an MQTT server"
@@ -28,8 +13,8 @@ WORKDIR /data
 COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # install rtl_433, rtl-sdr, libusb, mosquitto-clients, python3 py3-paho-mqtt; and deps of rtl_433_mqtt_hass.py.
 # make entry.sh and rtl_433_mqtt_hass.py executable.
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
-    echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
+RUN echo "https://nl.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
+    echo "https://nl.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
     apk update --quiet && \
     apk upgrade && \
     apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/home-assistant/amd64-base:3.20
+# Stick with 3.20 for now, as 3.21 and 3.22 are also problematic for you.
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.
@@ -27,7 +28,10 @@ WORKDIR /data
 COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # install rtl_433, rtl-sdr, libusb, mosquitto-clients, python3 py3-paho-mqtt; and deps of rtl_433_mqtt_hass.py.
 # make entry.sh and rtl_433_mqtt_hass.py executable.
-RUN apk add --no-cache rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
+    echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
+    apk update && \
+    apk add --no-cache rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
     chmod +x /scripts/entry.sh && \
     chmod +x /scripts/rtl_433_mqtt_hass.py
 

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+# ARG BUILD_FROM  <-- COMMENT THIS LINE OUT (or remove it)
+FROM ghcr.io/home-assistant/amd64-base:2024.05.0  # Or another recent, stable version
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,8 +1,23 @@
-FROM ghcr.io/home-assistant/amd64-base:3.20 
-# Using Alpine 3.20 base image for stability
+FROM ghcr.io/home-assistant/amd64-base:3.19 
+# Using Alpine 3.19 base image
 
 # Define environment variables
-# ... (rest of your ENV block unchanged) ...
+# Use this variable when creating a container to specify the MQTT broker host.
+ENV MQTT_HOST=127.0.0.1 \
+    MQTT_PORT=1883 \
+    MQTT_USERNAME="" \
+    MQTT_PASSWORD="" \
+    MQTT_RETAIN=True \
+    MQTT_TOPIC=rtl_433 \
+    PROTOCOL="" \
+    WHITELIST_ENABLE=False \
+    EXPIRE_AFTER=0 \
+    WHITELIST="" \
+    DISCOVERY_PREFIX=homeassistant \
+    DISCOVERY_INTERVAL=600 \
+    AUTO_DISCOVERY=True \
+    DEBUG=False \
+    LANG=C.UTF-8
 
 LABEL Maintainer="skipnyip" \
 Description="This image is used to start the RTL433 to HASS script that will monitor for 433Mhz devices and send the data to an MQTT server"
@@ -13,8 +28,8 @@ WORKDIR /data
 COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # install rtl_433, rtl-sdr, libusb, mosquitto-clients, python3 py3-paho-mqtt; and deps of rtl_433_mqtt_hass.py.
 # make entry.sh and rtl_433_mqtt_hass.py executable.
-RUN echo "https://nl.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
-    echo "https://nl.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main" > /etc/apk/repositories && \
+    echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community" >> /etc/apk/repositories && \
     apk update --quiet && \
     apk upgrade && \
     apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/home-assistant/amd64-base:3.20 # Stick with 3.20
+FROM ghcr.io/home-assistant/amd64-base:3.20
+# Stick with 3.20
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/amd64-base:2024.05.0 
+FROM ghcr.io/home-assistant/amd64-base:3.21
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/amd64-base:3.21
+FROM ghcr.io/home-assistant/amd64-base:3.20
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -30,7 +30,8 @@ COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # make entry.sh and rtl_433_mqtt_hass.py executable.
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
-    apk update --quiet --force-online && \
+    apk update --quiet && \
+    apk upgrade && \
     apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
     chmod +x /scripts/entry.sh && \
     chmod +x /scripts/rtl_433_mqtt_hass.py

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,5 +1,4 @@
-FROM ghcr.io/home-assistant/amd64-base:3.20
-# Stick with 3.20 for now, as 3.21 and 3.22 are also problematic for you.
+FROM ghcr.io/home-assistant/amd64-base:3.20 # Stick with 3.20
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.
@@ -30,8 +29,9 @@ COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # make entry.sh and rtl_433_mqtt_hass.py executable.
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories && \
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories && \
-    apk update && \
-    apk add --no-cache rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
+    apk cache clean && \  # Add this line to clear cache
+    apk update --quiet && \ # Added --quiet
+    apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \ # Added --verbose
     chmod +x /scripts/entry.sh && \
     chmod +x /scripts/rtl_433_mqtt_hass.py
 

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,5 +1,5 @@
-FROM ghcr.io/home-assistant/amd64-base:3.19 
-# Using Alpine 3.19 base image
+ARG BUILD_FROM
+FROM $BUILD_FROM
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.
@@ -28,11 +28,7 @@ WORKDIR /data
 COPY entry.sh rtl_433_mqtt_hass.py /scripts/
 # install rtl_433, rtl-sdr, libusb, mosquitto-clients, python3 py3-paho-mqtt; and deps of rtl_433_mqtt_hass.py.
 # make entry.sh and rtl_433_mqtt_hass.py executable.
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main" > /etc/apk/repositories && \
-    echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community" >> /etc/apk/repositories && \
-    apk update --quiet && \
-    apk upgrade && \
-    apk add --no-cache --verbose rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
+RUN apk add --no-cache rtl-sdr rtl_433 libusb mosquitto-clients python3 py3-paho-mqtt && \
     chmod +x /scripts/entry.sh && \
     chmod +x /scripts/rtl_433_mqtt_hass.py
 

--- a/acurite2mqtt/Dockerfile
+++ b/acurite2mqtt/Dockerfile
@@ -1,5 +1,4 @@
-# ARG BUILD_FROM  <-- COMMENT THIS LINE OUT (or remove it)
-FROM ghcr.io/home-assistant/amd64-base:2024.05.0  # Or another recent, stable version
+FROM ghcr.io/home-assistant/amd64-base:2024.05.0 
 
 # Define environment variables
 # Use this variable when creating a container to specify the MQTT broker host.

--- a/acurite2mqtt/config.json
+++ b/acurite2mqtt/config.json
@@ -3,7 +3,7 @@
   "version": "0.3.26",
   "slug": "acurite2mqtt",
   "description": "Acurite Sensors to Home Assistant via MQTT with Autodiscovery",
-  "url": "https://github.com/thejeffreystone/hassio_addons",
+  "url": "https://github.com/skipnyip/hassio_addons",
 
   "startup": "services",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],

--- a/acurite2mqtt/config.json
+++ b/acurite2mqtt/config.json
@@ -43,16 +43,6 @@
     "discovery_interval": "int",
     "auto_discovery": "bool",
     "debug": "bool"
-   },
-  "build": {
-    "default": "ghcr.io/home-assistant/{arch}-base",
-    "squash": true,
-    "build_from": {
-      "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
-      "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
-      "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
-      "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
-      "i386": "ghcr.io/home-assistant/i386-base:3.19"
-    }
+   }
   }
 }

--- a/acurite2mqtt/config.json
+++ b/acurite2mqtt/config.json
@@ -42,7 +42,17 @@
     "discovery_prefix": "str",
     "discovery_interval": "int",
     "auto_discovery": "bool",
-    "debug": "bool"
-   }
+    "debug": "bool
+   },
+  "build": {
+    "default": "ghcr.io/home-assistant/{arch}-base",
+    "squash": true,
+    "build_from": {
+      "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
+      "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
+      "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
+      "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
+      "i386": "ghcr.io/home-assistant/i386-base:3.19"
+    }
+  }
 }
-

--- a/acurite2mqtt/config.json
+++ b/acurite2mqtt/config.json
@@ -42,7 +42,7 @@
     "discovery_prefix": "str",
     "discovery_interval": "int",
     "auto_discovery": "bool",
-    "debug": "bool
+    "debug": "bool"
    },
   "build": {
     "default": "ghcr.io/home-assistant/{arch}-base",

--- a/acurite2mqtt/rtl_433_mqtt_hass.py
+++ b/acurite2mqtt/rtl_433_mqtt_hass.py
@@ -483,7 +483,7 @@ mappings = {
             "device_class": "illuminance",
             "state_class":"measurement",
             "name": "Outside Luminancee",
-            "unit_of_measurement": "lux",
+            "unit_of_measurement": "lx",
             "value_template": "{{ value|int }}"
         }
     },
@@ -494,7 +494,7 @@ mappings = {
         "config": {
             "device_class": "illuminance",
             "name": "Outside Luminancee",
-            "unit_of_measurement": "lux",
+            "unit_of_measurement": "lx",
             "value_template": "{{ value|int }}"
         }
     },
@@ -506,7 +506,7 @@ mappings = {
             "device_class": "illuminance",
             "state_class":"measurement",
             "name": "Brightness",
-            "unit_of_measurement": "lux",
+            "unit_of_measurement": "lx",
             "value_template": "{{ value|int }}"
         }
     },
@@ -515,7 +515,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "uv",
         "config": {
-            "device_class": "irradiance",
             "state_class":"measurement",
             "name": "UV Index",
             "unit_of_measurement": "UV Index",

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Home Assistant Add-ons: Slacker Labs",
-  "url": "https://github.com/thejeffreystone/hassio-addons",
-  "maintainer": "Jeffrey Stone"
+  "name": "Home Assistant Add-ons: skipnyip",
+  "url": "https://github.com/skipnyip/hassio-addons",
+  "maintainer": "skipnyip"
 }


### PR DESCRIPTION
Fixed issue where unit for brightness was coming as "lux" but Home Assistant requires it to be "lx" in version 2025-07. Removed invalid device_class from UV Index.

This is my first time ever doing a Pull Request or anything like that, soooooooooo use caution. lol